### PR TITLE
feat(ui): setup frontend base

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>frontend</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@tailwindcss/postcss": "^4.2.4",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -27,6 +28,19 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -276,7 +290,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -289,7 +302,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -301,7 +313,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -855,6 +866,277 @@
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.4.tgz",
+      "integrity": "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.4"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -1543,6 +1825,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1905,6 +2201,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1998,6 +2301,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2384,6 +2697,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2744,11 +3067,25 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@tailwindcss/postcss": "^4.2.4",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,7 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,167 @@
-function App() {
+import Button from '@/shared/ui/Button'
+import Card from '@/shared/ui/Card'
+import Input from '@/shared/ui/Input'
+import Badge from '@/shared/ui/Badge'
+import ListItem from '@/shared/ui/ListItem'
+import Spinner from '@/shared/ui/Spinner'
+import EmptyState from '@/shared/ui/EmptyState'
+
+export default function App() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold">Frontend initialized</h1>
+    <div className="min-h-screen bg-background text-text-main">
+      <div className="mx-auto max-w-5xl space-y-8 p-8">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">UI Component Stand</h1>
+          <p className="text-text-secondary">
+            Minimalist soft styles using provided design tokens.
+          </p>
+        </header>
+
+        <Card>
+          <h2 className="text-xl font-semibold">Button</h2>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Button>Primary</Button>
+            <Button variant="primary" className="hover:scale-[1.01]">
+              Primary hover
+            </Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="danger">Danger</Button>
+
+            <Button disabled>Disabled</Button>
+            <Button loading>Loading</Button>
+            <Button variant="secondary" disabled>
+              Disabled secondary
+            </Button>
+          </div>
+        </Card>
+
+        <Card>
+          <h2 className="text-xl font-semibold">Input</h2>
+          <div className="mt-4 space-y-4 max-w-md">
+            <Input label="Email" placeholder="user@example.com" />
+            <Input
+              label="Disabled"
+              placeholder="—"
+              disabled
+              defaultValue="locked@example.com"
+            />
+            <Input
+              label="Error"
+              placeholder="wrong@email"
+              error
+              errorMessage="Некорректный формат email"
+              defaultValue="wrong@email"
+            />
+            <Input
+              label="With hint"
+              placeholder="type something"
+              hint="This is a hint under the field"
+            />
+          </div>
+        </Card>
+
+        <Card>
+          <h2 className="text-xl font-semibold">Cards</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-3">
+            <Card variant="default">
+              <div className="text-sm font-medium">Default card</div>
+              <div className="mt-1 text-sm text-text-secondary">
+                White background + border.
+              </div>
+            </Card>
+            <Card variant="soft">
+              <div className="text-sm font-medium">Soft card</div>
+              <div className="mt-1 text-sm text-text-secondary">
+                Soft background + light border.
+              </div>
+            </Card>
+            <Card variant="outline">
+              <div className="text-sm font-medium">Outline card</div>
+              <div className="mt-1 text-sm text-text-secondary">
+                Transparent fill.
+              </div>
+            </Card>
+          </div>
+        </Card>
+
+        <Card>
+          <h2 className="text-xl font-semibold">Badge</h2>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Badge>Neutral</Badge>
+            <Badge variant="processing">Processing</Badge>
+            <Badge variant="success">Completed</Badge>
+            <Badge variant="error">Failed</Badge>
+            <Badge variant="success" size="md">
+              Completed (md)
+            </Badge>
+          </div>
+        </Card>
+
+        <Card>
+          <h2 className="text-xl font-semibold">ListItem</h2>
+          <div className="mt-4 space-y-3">
+            <ListItem
+              leading={
+                <div className="h-10 w-10 rounded-md border border-border bg-primary" />
+              }
+              title="Analysis #1"
+              secondary="Skin type: oily • Completed recently"
+              status="completed"
+            />
+            <ListItem
+              leading={
+                <div className="h-10 w-10 rounded-md border border-border bg-card-soft" />
+              }
+              title="Analysis #2"
+              secondary="Currently processing the photo..."
+              status="processing"
+            />
+            <ListItem
+              leading={
+                <div className="h-10 w-10 rounded-md border border-border bg-error/15" />
+              }
+              title="Analysis #3"
+              secondary="Failed due to upload error"
+              status="failed"
+            />
+            <ListItem
+              leading={
+                <div className="h-10 w-10 rounded-md border border-border bg-card" />
+              }
+              title="Custom trailing"
+              secondary="Trailing slot instead of status badge"
+              trailing={<Badge variant="neutral">Custom</Badge>}
+            />
+          </div>
+        </Card>
+
+        <Card>
+          <h2 className="text-xl font-semibold">Spinner</h2>
+          <div className="mt-4 flex items-center gap-4">
+            <Spinner size="sm" />
+            <Spinner size="md" />
+            <Spinner size="lg" />
+          </div>
+        </Card>
+
+        <Card>
+          <h2 className="text-xl font-semibold">EmptyState</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <EmptyState
+              title="No analyses yet"
+              description="Upload a photo to get your skin type and recommendations."
+              actionLabel="Go to upload (mock)"
+              onAction={() => {}}
+            />
+            <EmptyState
+              title="Nothing to show"
+              description="This state has no action."
+              icon={<span className="text-3xl">:)</span>}
+            />
+          </div>
+        </Card>
+      </div>
     </div>
   )
 }
-
-export default App

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,28 @@
 @import "tailwindcss";
+
+@theme {
+  --color-background: #F3F5F0;
+  --color-card: #FFFFFF;
+  --color-card-soft: #F3F5F0;
+  --color-primary: #F6DCDD;
+  --color-primary-hover: #EFC8CB;
+  --color-accent-green: #C2D3AF;
+  --color-text-main: #464742;
+  --color-text-secondary: #66625E;
+  --color-border: #E6E6E0;
+  --color-input-bg: #FFFFFF;
+  --color-error: #D96C6C;
+
+  --font-sans: Montserrat, ui-sans-serif, system-ui, Arial, sans-serif;
+
+  --radius-sm: 8px;
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --radius-xl: 28px;
+}
+
+@layer base {
+  body {
+    @apply bg-background text-text-main font-sans antialiased;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import '@/index.css'
+import './index.css'
 import App from '@/App'
 import { Providers } from '@/app/providers'
 

--- a/src/shared/lib/cn.ts
+++ b/src/shared/lib/cn.ts
@@ -1,0 +1,4 @@
+export function cn(...classes: Array<string | undefined | null | false>): string {
+  return classes.filter(Boolean).join(' ')
+}
+

--- a/src/shared/ui/Badge.tsx
+++ b/src/shared/ui/Badge.tsx
@@ -1,0 +1,47 @@
+import { type ReactNode } from 'react'
+import { cn } from '../lib/cn'
+
+export type BadgeVariant = 'neutral' | 'success' | 'error' | 'processing'
+export type BadgeSize = 'sm' | 'md'
+
+export type BadgeProps = {
+  variant?: BadgeVariant
+  size?: BadgeSize
+  className?: string
+  children: ReactNode
+}
+
+export default function Badge({
+  variant = 'neutral',
+  size = 'sm',
+  className,
+  children,
+}: BadgeProps) {
+  const sizeClasses =
+    size === 'md'
+      ? 'px-2.5 py-1 text-sm'
+      : 'px-2 py-0.5 text-xs'
+
+  const variantClasses =
+    variant === 'success'
+      ? 'bg-accent-green/30 border-accent-green/60 text-text-main'
+      : variant === 'error'
+        ? 'bg-error/15 border-error/40 text-error'
+        : variant === 'processing'
+          ? 'bg-primary/25 border-primary/50 text-text-secondary'
+          : 'bg-card-soft border-border text-text-secondary'
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-sm border font-medium',
+        sizeClasses,
+        variantClasses,
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -1,0 +1,66 @@
+import { type ReactNode, type ButtonHTMLAttributes } from 'react'
+import Spinner from './Spinner'
+import { cn } from '../lib/cn'
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger'
+export type ButtonSize = 'sm' | 'md' | 'lg'
+
+export type ButtonProps = {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  loading?: boolean
+  leftIcon?: ReactNode
+  rightIcon?: ReactNode
+  className?: string
+  disabled?: boolean
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'disabled'>
+
+export default function Button({
+  variant = 'primary',
+  size = 'md',
+  loading = false,
+  disabled = false,
+  className,
+  leftIcon,
+  rightIcon,
+  type = 'button',
+  ...props
+}: ButtonProps) {
+  const isDisabled = disabled || loading
+
+  const sizeClasses =
+    size === 'sm'
+      ? 'px-3 py-2 text-sm'
+      : size === 'lg'
+        ? 'px-5 py-3 text-base'
+        : 'px-4 py-2.5 text-sm'
+
+  const variantClasses =
+    variant === 'primary'
+      ? 'bg-primary hover:bg-primary-hover text-text-main border border-primary'
+      : variant === 'secondary'
+        ? 'bg-[#C2D3AF] border border-border text-text-main hover:bg-card-soft'
+        : variant === 'danger'
+          ? 'bg-error hover:bg-error/90 text-card border border-error'
+          : 'bg-transparent border border-transparent text-text-main hover:bg-card-soft'
+
+  return (
+    <button
+      type={type}
+      disabled={isDisabled}
+      className={cn(
+        'inline-flex items-center justify-center gap-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-green/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-colors',
+        sizeClasses,
+        variantClasses,
+        'disabled:cursor-not-allowed disabled:opacity-60',
+        className,
+      )}
+      {...props}
+    >
+      {loading ? <Spinner size="sm" /> : leftIcon}
+      {props.children}
+      {loading ? null : rightIcon}
+    </button>
+  )
+}
+

--- a/src/shared/ui/Card.tsx
+++ b/src/shared/ui/Card.tsx
@@ -1,0 +1,30 @@
+import { type ReactNode } from 'react'
+import { cn } from '../lib/cn'
+
+export type CardVariant = 'default' | 'soft' | 'outline'
+
+export type CardProps = {
+  variant?: CardVariant
+  className?: string
+  children?: ReactNode
+}
+
+export default function Card({
+  variant = 'default',
+  className,
+  children,
+}: CardProps) {
+  const variantClasses =
+    variant === 'soft'
+      ? 'bg-card-soft border border-border'
+      : variant === 'outline'
+        ? 'bg-transparent border border-border'
+        : 'bg-card border border-border'
+
+  return (
+    <div className={cn('rounded-md p-6', variantClasses, className)}>
+      {children}
+    </div>
+  )
+}
+

--- a/src/shared/ui/EmptyState.tsx
+++ b/src/shared/ui/EmptyState.tsx
@@ -1,0 +1,45 @@
+import { type ReactNode } from 'react'
+import Button from './Button'
+import { cn } from '../lib/cn'
+
+export type EmptyStateProps = {
+  title: string
+  description?: string
+  icon?: ReactNode
+  actionLabel?: string
+  onAction?: () => void
+  className?: string
+}
+
+export default function EmptyState({
+  title,
+  description,
+  icon,
+  actionLabel,
+  onAction,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-md border border-border bg-card-soft p-8 text-center',
+        className,
+      )}
+    >
+      {icon ? <div className="mx-auto mb-3">{icon}</div> : null}
+      <div className="text-lg font-semibold text-text-main">{title}</div>
+      {description ? (
+        <div className="mt-2 text-sm text-text-secondary">{description}</div>
+      ) : null}
+
+      {actionLabel && onAction ? (
+        <div className="mt-5">
+          <Button variant="secondary" onClick={onAction}>
+            {actionLabel}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -1,0 +1,60 @@
+import { useId, type InputHTMLAttributes } from 'react'
+import { cn } from '../lib/cn'
+
+export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
+  label?: string
+  hint?: string
+  error?: boolean
+  errorMessage?: string
+}
+
+export default function Input({
+  label,
+  hint,
+  error,
+  errorMessage,
+  id,
+  disabled,
+  className,
+  ...props
+}: InputProps) {
+  const generatedId = useId()
+  const inputId = id ?? generatedId
+
+  const showError = Boolean(error || errorMessage)
+
+  return (
+    <div className={cn('w-full', className)}>
+      {label ? (
+        <label
+          htmlFor={inputId}
+          className="mb-1 block text-sm font-medium text-text-secondary"
+        >
+          {label}
+        </label>
+      ) : null}
+
+      <input
+        id={inputId}
+        disabled={disabled}
+        className={cn(
+          'block w-full rounded-md border px-3 py-2 text-sm bg-input-bg text-text-main placeholder:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-green/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          showError
+            ? 'border-error focus-visible:ring-error/30'
+            : 'border-border',
+          disabled
+            ? 'bg-card-soft text-text-secondary cursor-not-allowed'
+            : null,
+        )}
+        {...props}
+      />
+
+      {showError && errorMessage ? (
+        <div className="mt-1 text-sm text-error">{errorMessage}</div>
+      ) : hint ? (
+        <div className="mt-1 text-sm text-text-secondary">{hint}</div>
+      ) : null}
+    </div>
+  )
+}
+

--- a/src/shared/ui/ListItem.tsx
+++ b/src/shared/ui/ListItem.tsx
@@ -1,0 +1,55 @@
+import { type ReactNode } from 'react'
+import { cn } from '../lib/cn'
+import Badge from './Badge'
+
+export type ListItemStatus = 'processing' | 'completed' | 'failed'
+
+export type ListItemProps = {
+  title: ReactNode
+  secondary?: ReactNode
+  leading?: ReactNode
+  trailing?: ReactNode
+  status?: ListItemStatus
+  className?: string
+}
+
+export default function ListItem({
+  title,
+  secondary,
+  leading,
+  trailing,
+  status,
+  className,
+}: ListItemProps) {
+  const statusBadge =
+    status === 'processing' ? (
+      <Badge variant="processing">Processing</Badge>
+    ) : status === 'completed' ? (
+      <Badge variant="success">Completed</Badge>
+    ) : status === 'failed' ? (
+      <Badge variant="error">Failed</Badge>
+    ) : null
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-3 rounded-md border border-border bg-card p-4',
+        className,
+      )}
+    >
+      {leading ? <div className="mt-0.5 flex-shrink-0">{leading}</div> : null}
+
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-text-main">{title}</div>
+        {secondary ? (
+          <div className="mt-1 text-sm text-text-secondary">{secondary}</div>
+        ) : null}
+      </div>
+
+      <div className="flex flex-shrink-0 items-start gap-2">
+        {trailing ? trailing : statusBadge}
+      </div>
+    </div>
+  )
+}
+

--- a/src/shared/ui/Spinner.tsx
+++ b/src/shared/ui/Spinner.tsx
@@ -1,0 +1,23 @@
+export type SpinnerSize = 'sm' | 'md' | 'lg'
+
+export type SpinnerProps = {
+  size?: SpinnerSize
+  className?: string
+}
+
+export default function Spinner({ size = 'md', className }: SpinnerProps) {
+  const dim =
+    size === 'sm' ? 'h-4 w-4' : size === 'lg' ? 'h-6 w-6' : 'h-5 w-5'
+
+  return (
+    <span
+      aria-label="Loading"
+      className={[
+        'inline-block animate-spin rounded-full border-2 border-text-main/20 border-t-text-main',
+        dim,
+        className,
+      ].filter(Boolean).join(' ')}
+    />
+  )
+}
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,31 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#F3F5F0',
+        card: '#FFFFFF',
+        'card-soft': '#F3F5F0',
+        primary: '#F6DCDD',
+        'primary-hover': '#EFC8CB',
+        'accent-green': '#C2D3AF',
+        'text-main': '#464742',
+        'text-secondary': '#66625E',
+        border: '#E6E6E0',
+        'input-bg': '#FFFFFF',
+        error: '#D96C6C',
+      },
+      fontFamily: {
+        sans: ['Montserrat', 'ui-sans-serif', 'system-ui', 'Arial', 'sans-serif'],
+      },
+      borderRadius: {
+        sm: '8px',
+        md: '16px',
+        lg: '24px',
+        xl: '28px',
+      },
+    },
+  },
+}
+

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,7 +22,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
 
-    "ignoreDeprecations": "6.0",
+    // Keep config compatible with the current TypeScript version.
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
Настроили Tailwind CSS v4 под Vite: PostCSS с @tailwindcss/postcss, postcss.config.js, импорт ./index.css в main.tsx, content в tailwind.config.js.
Задали дизайн-токены (цвета, Montserrat, радиусы) через @theme в index.css, базовые стили для body.
Добавили переиспользуемые UI-компоненты в src/shared/ui: Button, Input, Card, Badge, ListItem, Spinner, EmptyState + утилита cn.
Собрали компонентный стенд в App.tsx со всеми основными состояниями (варианты, disabled, error, loading и т.д.).
Установили @tailwindcss/postcss; поправили tsconfig.app.json (убрана несовместимая опция ignoreDeprecations), сборка и линт проходят.